### PR TITLE
Multiselect functional

### DIFF
--- a/lib/components/Multiselect/index.js
+++ b/lib/components/Multiselect/index.js
@@ -1,7 +1,8 @@
 import React, {PropTypes, Component} from 'react';
+import isEmpty from 'lodash/isEmpty';
+import merge from 'lodash/merge';
 import Select from '../Select';
 import Tags from '../Tags';
-
 
 /**********
  * How to use:
@@ -10,7 +11,16 @@ import Tags from '../Tags';
  *   options={this.state.options}
  *   value={this.state.selected}
  *   onChange={(selected) => this.setState({selected})}
- *   onSelect={(selected) => this.setState({selected})}
+ * />
+ *
+ * or as following for redux-forms:
+ *
+ * <Multiselect
+ *   options={this.state.skills}
+ *   input={{
+ *     value: this.state.selected,
+ *     onChange: (selected) => this.setState({selected}),
+ *   }}
  * />
  *********/
 class Multiselect extends Component {
@@ -18,8 +28,6 @@ class Multiselect extends Component {
   constructor(props) {
     super(props);
     this.onBlur = this.onBlur.bind(this);
-    this.onTagRemove = this.onTagRemove.bind(this);
-    this.onTagAdd = this.onTagAdd.bind(this);
   }
 
   static propTypes = {
@@ -27,11 +35,13 @@ class Multiselect extends Component {
     options: PropTypes.array,
     value: PropTypes.oneOfType([PropTypes.string, PropTypes.array]),
     onInputChange: PropTypes.func,
+    onChange: PropTypes.func,
     label: PropTypes.string,
     selectLabel: PropTypes.string,
     tagsLabel: PropTypes.string,
     onFocus: PropTypes.func,
     onBlur: PropTypes.func,
+    renderTags: PropTypes.bool,
 
     input: PropTypes.shape({
       name: PropTypes.string,
@@ -61,7 +71,9 @@ class Multiselect extends Component {
   };
   static defaultProps = {
     input: {},
-    meta: {}
+    meta: {},
+    multi: true,
+    renderTags: false
   };
 
   render() {
@@ -77,8 +89,7 @@ class Multiselect extends Component {
       options: this.props.options,
       optionRenderer: this.props.optionRenderer,
       onInputChange: this.props.onInputChange,
-      onChange: this.onTagAdd || input.onChange,
-      onSelect: this.props.onSelect,
+      onSelect: this.onTagAdd,
       onBlur: this.onBlur,
       onFocus: this.props.onFocus || input.onFocus,
       isLoading: this.props.isLoading,
@@ -86,19 +97,20 @@ class Multiselect extends Component {
       matchPos: this.props.matchPos,
       matchProp: this.props.matchProp,
       arrowRenderer: this.props.arrowRenderer,
-      multi: true,
+      multi: this.props.multi,
       simpleValue: this.props.simpleValue,
       disabled: this.props.disabled,
       clearable: this.props.clearable,
       searchable: this.props.searchable,
       clearIcon: this.props.clearIcon,
       clearIconHTML: this.props.clearIconHTML,
-      noArrow: this.props.noArrow
+      noArrow: this.props.noArrow,
+      renderTags: this.props.renderTags
     };
     const tagsProps = {
       id: this.props.tagsId,
       label: this.props.tagsLabel,
-      tags: this.props.value,
+      tags: this.props.value || input.value,
       onClick: this.props.onClick,
       onTagRemove: this.onTagRemove,
       hideClose: this.props.hideClose,
@@ -141,20 +153,39 @@ class Multiselect extends Component {
 
   }
 
-  onTagRemove(tag) {
+  onTagRemove = (tag) => {
     const {input, value, onChange} = this.props;
-    const newTags = value.filter(t => t.value !== tag.value);
+
+    const newTags = value
+      ? value.filter(t => t.value !== tag.value)
+      : input.value.filter(t => t.value !== tag.value);
 
     if (onChange) onChange(newTags);
     if (!onChange && input.onChange) input.onChange(newTags);
   }
 
-  onTagAdd({value, label}) {
+  onTagAdd = (updVal) => {
     const {input, onChange} = this.props;
-    const newValues = [this.props.value, {value, label}];
 
-    if (onChange) onChange(newValues);
-    if (!onChange && input.onChange) input.onChange(newValues);
+    const oldVal = this.getOldValue();
+    const newVal = merge(oldVal, updVal);  // multi => arrays merge
+
+    if (onChange) onChange(newVal);
+    if (!onChange && input.onChange) input.onChange(newVal);
+  }
+
+  getOldValue = () => {
+    let oldValue = [];  // Array because multi
+
+    if (!isEmpty(this.props.input.value)) {
+      return oldValue = this.props.input.value;
+    }
+
+    if (!isEmpty(this.props.value)) {
+      return oldValue = this.props.value;
+    }
+
+    return oldValue;
   }
 
 }

--- a/lib/components/Multiselect/index.js
+++ b/lib/components/Multiselect/index.js
@@ -1,14 +1,129 @@
-import React, {PropTypes} from 'react';
+import React, {PropTypes, Component} from 'react';
 import Select from '../Select';
 import Tags from '../Tags';
 
-const Multiselect = (props) => {
-  const {meta, input, label, id} = props;
-  const {error, invalid, touched, dirty} = meta;
+
+/**********
+ * How to use:
+ *
+ * <Multiselect
+ *   options={this.state.options}
+ *   value={this.state.selected}
+ *   onChange={(selected) => this.setState({selected})}
+ *   onSelect={(selected) => this.setState({selected})}
+ * />
+ *********/
+class Multiselect extends Component {
+
+  constructor(props) {
+    super(props);
+    this.onBlur = this.onBlur.bind(this);
+    this.onTagRemove = this.onTagRemove.bind(this);
+    this.onTagAdd = this.onTagAdd.bind(this);
+  }
+
+  static propTypes = {
+    id: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+    options: PropTypes.array,
+    value: PropTypes.oneOfType([PropTypes.string, PropTypes.array]),
+    onInputChange: PropTypes.func,
+    label: PropTypes.string,
+    selectLabel: PropTypes.string,
+    tagsLabel: PropTypes.string,
+    onFocus: PropTypes.func,
+    onBlur: PropTypes.func,
+
+    input: PropTypes.shape({
+      name: PropTypes.string,
+      onBlur: PropTypes.func,
+      onChange: PropTypes.func,  // mutates the redux-form Field data
+      onDragStart: PropTypes.func,
+      onDrop: PropTypes.func,
+      onFocus: PropTypes.func,
+      value: PropTypes.oneOfType([PropTypes.string, PropTypes.array])
+    }),
+
+    meta: PropTypes.shape({
+      active: PropTypes.bool,
+      asyncValidating: PropTypes.bool,
+      autofilled: PropTypes.bool,
+      dirty: PropTypes.bool,
+      dispatch: PropTypes.func,
+      error: PropTypes.string,
+      invalid: PropTypes.bool,
+      pristine: PropTypes.bool,
+      submitting: PropTypes.bool,
+      touched: PropTypes.bool,
+      valid: PropTypes.bool,
+      visited: PropTypes.bool,
+      warning: PropTypes.string
+    })
+  };
+  static defaultProps = {
+    input: {},
+    meta: {}
+  };
+
+  render() {
+    const {meta, input, label, id} = this.props;
+    const {error, invalid, touched, dirty} = meta;
+
+    const selectProps = {
+      label: this.props.selectLabel,
+      name: this.props.name || input.name,
+      placeholder: this.props.placeholder,
+      value: this.props.value || input.value,
+      loadOptions: this.props.loadOptions,
+      options: this.props.options,
+      optionRenderer: this.props.optionRenderer,
+      onInputChange: this.props.onInputChange,
+      onChange: this.onTagAdd || input.onChange,
+      onSelect: this.props.onSelect,
+      onBlur: this.onBlur,
+      onFocus: this.props.onFocus || input.onFocus,
+      isLoading: this.props.isLoading,
+      noResultsText: this.props.noResultsText,
+      matchPos: this.props.matchPos,
+      matchProp: this.props.matchProp,
+      arrowRenderer: this.props.arrowRenderer,
+      multi: true,
+      simpleValue: this.props.simpleValue,
+      disabled: this.props.disabled,
+      clearable: this.props.clearable,
+      searchable: this.props.searchable,
+      clearIcon: this.props.clearIcon,
+      clearIconHTML: this.props.clearIconHTML,
+      noArrow: this.props.noArrow
+    };
+    const tagsProps = {
+      id: this.props.tagsId,
+      label: this.props.tagsLabel,
+      tags: this.props.value,
+      onClick: this.props.onClick,
+      onTagRemove: this.onTagRemove,
+      hideClose: this.props.hideClose,
+      closeIcon: this.props.closeIcon,
+      extended: this.props.extended,
+      inactive: this.props.inactive
+    };
+
+    return (
+      <div className='multiselect'>
+
+        {label && <label htmlFor={id}>{label}</label>}
+
+        <Select {...selectProps} />
+        <Tags   {...tagsProps} />
+
+        <span>{(dirty || touched) && invalid && error}</span>
+
+      </div>
+    );
+  }
 
   // Replication of the same function in Select
-  const onBlur = (e) => {
-    const {onBlur, value, input} = this.props;
+  onBlur(e) {
+    const {onBlur, value, input, options} = this.props;
 
     if (typeof onBlur === 'function') return onBlur(e);
 
@@ -17,118 +132,31 @@ const Multiselect = (props) => {
       const val = value || input.value;
 
       if (typeof val === 'string') {
-        const loc = props.options.find(l => l.value === val);
+        const loc = options.find(l => l.value === val);
         return input.onBlur(loc);
       }
 
       return input.onBlur(val);
     }
 
-  };
+  }
 
-  const onTagRemove = (tag) => {
-    const newTags = props.tags.filter(t => t.value !== tag.value);
+  onTagRemove(tag) {
+    const {input, value, onChange} = this.props;
+    const newTags = value.filter(t => t.value !== tag.value);
 
-    if (props.onChange) props.onChange(newTags);
-    if (!props.onChange && input.onChange) input.onChange(newTags);
-  };
+    if (onChange) onChange(newTags);
+    if (!onChange && input.onChange) input.onChange(newTags);
+  }
 
-  const onTagAdd = ({value, label}) => {
-    const newTags = [props.tags, {value, label}];
+  onTagAdd({value, label}) {
+    const {input, onChange} = this.props;
+    const newValues = [this.props.value, {value, label}];
 
-    if (props.onChange) props.onChange(newTags);
-    if (!props.onChange && input.onChange) input.onChange(newTags);
-  };
+    if (onChange) onChange(newValues);
+    if (!onChange && input.onChange) input.onChange(newValues);
+  }
 
-  const selectProps = {
-    label: props.selectLabel,  // different
-    name: props.name || input.name,
-    placeholder: props.placeholder,
-    value: props.value || input.value,
-    loadOptions: props.loadOptions,
-    options: props.options,
-    optionRenderer: props.optionRenderer,
-    onChange: props.onChange,
-    onSelect: onTagAdd,        // different
-    onBlur,
-    onFocus: props.onFocus || input.onFocus,
-    isLoading: props.isLoading,
-    noResultsText: props.noResultsText,
-    matchPos: props.matchPos,
-    matchProp: props.matchProp,
-    arrowRenderer: props.arrowRenderer,
-    multi: props.multi,
-    simpleValue: props.simpleValue,
-    disabled: props.disabled,
-    clearable: props.clearable,
-    searchable: props.searchable,
-    clearIcon: props.clearIcon,
-    clearIconHTML: props.clearIconHTML,
-    noArrow: props.noArrow
-  };
-  const tagsProps = {
-    id: props.tagsId,        // different
-    label: props.tagsLabel,  // different
-    tags: props.tags,
-    onClick: props.onClick,
-    onTagRemove,    // different
-    hideClose: props.hideClose,
-    closeIcon: props.closeIcon,
-    extended: props.extended,
-    inactive: props.inactive
-  };
-
-  return (
-    <div className='multiselect'>
-
-      {label && <label htmlFor={id}>{label}</label>}
-
-      <Select {...selectProps} />
-      <Tags   {...tagsProps} />
-
-      <span>{(dirty || touched) && invalid && error}</span>
-
-    </div>
-  );
-};
-
-Multiselect.propTypes = {
-  label: PropTypes.string,
-  id: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
-  tags: PropTypes.array,
-  options: PropTypes.array,
-  selectProps: PropTypes.object,
-  tagsProps: PropTypes.object,
-
-  input: PropTypes.shape({
-    name: PropTypes.string,
-    onBlur: PropTypes.func,
-    onChange: PropTypes.func,
-    onDragStart: PropTypes.func,
-    onDrop: PropTypes.func,
-    onFocus: PropTypes.func,
-    value: PropTypes.string
-  }),
-
-  meta: PropTypes.shape({
-    active: PropTypes.bool,
-    asyncValidating: PropTypes.bool,
-    autofilled: PropTypes.bool,
-    dirty: PropTypes.bool,
-    dispatch: PropTypes.func,
-    error: PropTypes.string,
-    invalid: PropTypes.bool,
-    pristine: PropTypes.bool,
-    submitting: PropTypes.bool,
-    touched: PropTypes.bool,
-    valid: PropTypes.bool,
-    visited: PropTypes.bool,
-    warning: PropTypes.string
-  })
-};
-Multiselect.defaultProps = {
-  input: {},
-  meta: {}
-};
+}
 
 export default Multiselect;

--- a/lib/components/Multiselect/index.js
+++ b/lib/components/Multiselect/index.js
@@ -33,7 +33,14 @@ class Multiselect extends Component {
   static propTypes = {
     id: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
     options: PropTypes.array,
-    value: PropTypes.oneOfType([PropTypes.string, PropTypes.array]),
+    value: PropTypes.oneOfType([
+      PropTypes.string,
+      PropTypes.array,
+      PropTypes.arrayOf(PropTypes.shape({
+        value: PropTypes.string,
+        label: PropTypes.string
+      }))
+    ]),
     onInputChange: PropTypes.func,
     onChange: PropTypes.func,
     label: PropTypes.string,
@@ -50,7 +57,14 @@ class Multiselect extends Component {
       onDragStart: PropTypes.func,
       onDrop: PropTypes.func,
       onFocus: PropTypes.func,
-      value: PropTypes.oneOfType([PropTypes.string, PropTypes.array])
+      value: PropTypes.oneOfType([
+        PropTypes.string,
+        PropTypes.array,
+        PropTypes.arrayOf(PropTypes.shape({
+          value: PropTypes.string,
+          label: PropTypes.string
+        }))
+      ])
     }),
 
     meta: PropTypes.shape({

--- a/lib/components/Select/index.js
+++ b/lib/components/Select/index.js
@@ -24,7 +24,6 @@ class Select extends Component {
     this.arrowRenderer = this.arrowRenderer.bind(this);
     this.optionRenderer = this.optionRenderer.bind(this);
     this.onBlur = this.onBlur.bind(this);
-    this.getValueComponent = this.getValueComponent.bind(this);
   }
 
   static propTypes = {
@@ -52,6 +51,7 @@ class Select extends Component {
     label: PropTypes.oneOfType([PropTypes.string, PropTypes.element]),
     clearIconHTML: PropTypes.string,  // DANGER !
     noArrow: PropTypes.bool,
+    renderTags: PropTypes.bool,
 
     input: PropTypes.shape({
       name: PropTypes.string,
@@ -95,6 +95,7 @@ class Select extends Component {
     clearable: true,
     searchable: true,
     arrowRenderer: undefined,
+    renderTags: true,
     clearIconHTML: '<i class="mb-icons-cross"/>'  // DANGER !
   };
 
@@ -149,10 +150,6 @@ class Select extends Component {
 
   }
 
-  getValueComponent() {
-    if (this.props.multi) return null;
-  }
-
   render() {
     const {
       meta, input, placeholder, loadOptions, options, onInputChange, onSelect,
@@ -167,7 +164,7 @@ class Select extends Component {
       if (option.isCategory) {
         return {
           label: option.label,
-          value: undefined,
+          value: option.value,
           disabled: true,
           isCategory: true
         };
@@ -184,6 +181,11 @@ class Select extends Component {
       'select-success': (touched && valid)
     });
 
+    // 'react-select' expects a function in props.valueComponent
+    // If not multi - then should not pass this prop at all
+    const valueComponent = {};
+    if (!this.props.renderTags) valueComponent.valueComponent = () => null;
+
     // ? use focusedOptionIndex for dropdown box item focus
     return (
       <div className={wrapperCss}>
@@ -191,11 +193,11 @@ class Select extends Component {
         {label && <label htmlFor={id}>{label}</label>}
 
         <ReactSelect
+          {...valueComponent}
           className={selectCss}
           name={name || input.name}
           placeholder={placeholder}
           value={value || input.value}
-          valueComponent={this.getValueComponent}
           options={updOptions}
           onInputChange={onInputChange}
           onChange={onSelect || input.onChange}

--- a/lib/components/Select/index.js
+++ b/lib/components/Select/index.js
@@ -19,10 +19,18 @@ import cn from 'classnames';
  *********/
 class Select extends Component {
 
+  constructor(props) {
+    super(props);
+    this.arrowRenderer = this.arrowRenderer.bind(this);
+    this.optionRenderer = this.optionRenderer.bind(this);
+    this.onBlur = this.onBlur.bind(this);
+    this.getValueComponent = this.getValueComponent.bind(this);
+  }
+
   static propTypes = {
     name: PropTypes.string,
     placeholder: PropTypes.string,
-    value: PropTypes.string,
+    value: PropTypes.oneOfType([PropTypes.string, PropTypes.array]),
     loadOptions: PropTypes.bool,
     options: PropTypes.array,
     optionRenderer: PropTypes.bool,
@@ -52,7 +60,7 @@ class Select extends Component {
       onDragStart: PropTypes.func,
       onDrop: PropTypes.func,
       onFocus: PropTypes.func,
-      value: PropTypes.string
+      value: PropTypes.oneOfType([PropTypes.string, PropTypes.array])
     }),
 
     meta: PropTypes.shape({
@@ -141,6 +149,10 @@ class Select extends Component {
 
   }
 
+  getValueComponent() {
+    if (this.props.multi) return null;
+  }
+
   render() {
     const {
       meta, input, placeholder, loadOptions, options, onInputChange, onSelect,
@@ -172,6 +184,7 @@ class Select extends Component {
       'select-success': (touched && valid)
     });
 
+    // ? use focusedOptionIndex for dropdown box item focus
     return (
       <div className={wrapperCss}>
 
@@ -182,6 +195,7 @@ class Select extends Component {
           name={name || input.name}
           placeholder={placeholder}
           value={value || input.value}
+          valueComponent={this.getValueComponent}
           options={updOptions}
           onInputChange={onInputChange}
           onChange={onSelect || input.onChange}


### PR DESCRIPTION
Multiselect should be refactored to work with and without redux-forms

the same refactoring as with Select:
onChange - > onInputChange - the same as Select
multi: true - should be by default

incoming props:
label
selectLabel
tagsLabel
options
value
onInputChange
onChange (should be triggered in both cases, item added, item removed), it handles internally (onSelect and Tagchanges) from child components
onFocus
onBlur